### PR TITLE
fix: AntiViralEligibilityQuestionnaire validation

### DIFF
--- a/input/fsh/canonical/antiviraleligibilityquestionnaire.fsh
+++ b/input/fsh/canonical/antiviraleligibilityquestionnaire.fsh
@@ -163,7 +163,7 @@ Usage: #definition
 * title = "AntiViral Eligibility Review"
 * subjectType = #Patient
 * version = "1.0.0"
-* url = "https://build.fhir.org/ig/tewhatuora/cinc-fhir-ig/Questionnaire-AntiViralEligibilityQuestionnaire"
+* url = "https://build.fhir.org/ig/tewhatuora/cinc-fhir-ig/Questionnaire/Questionnaire-AntiViralEligibilityQuestionnaire"
 * meta.lastUpdated = "2023-03-14T04:51:54.576Z"
 * meta.versionId = "2"
 * name = "AntiViralEligibilityQuestionTemplate"

--- a/input/fsh/examples/antiviraleligibilityquestionnaireresponse.fsh
+++ b/input/fsh/examples/antiviraleligibilityquestionnaireresponse.fsh
@@ -3,7 +3,7 @@ InstanceOf: QuestionnaireResponse
 Usage: #example
 * status = #completed
 * authored = "2023-03-20"
-* questionnaire = "https://build.fhir.org/ig/tewhatuora/cinc-fhir-ig/Questionnaire-AntiViralEligibilityQuestionnaire"
+* questionnaire = "https://build.fhir.org/ig/tewhatuora/cinc-fhir-ig/Questionnaire/Questionnaire-AntiViralEligibilityQuestionnaire"
 * subject.type = "Patient"
 * subject.identifier.use = #official
 * subject.identifier.system = "https://standards.digital.health.nz/ns/nhi-id"


### PR DESCRIPTION
Fixes the below validation errors

![image](https://user-images.githubusercontent.com/83252538/227802604-e8a57ebf-0d4c-4d5b-b54d-e50f4e52fa4e.png)

Any QuestionnaireResponses will need to use `https://build.fhir.org/ig/tewhatuora/cinc-fhir-ig/Questionnaire/Questionnaire-AntiViralEligibilityQuestionnaire` as the canonical questionnaire url