### PR TITLE
Feature/upgrade anti viral eligibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,17 @@
 # Changelog
 
-# v0.1.9 (2023-07-27)
+## v0.2.0 (2023-08-01)
+- Updated **AntiViralEligibility** Questionnaire to align with CCCM per ticket CFFF-889 and also codify two of the criteria
+- See the [v0.2.0 release note](/releaseNotes/v0.2.0.md) for detail on breaking changes to QuestionnaireResponses from this Questionnaire update
+
+## v0.1.9 (2023-07-27)
 
 - Removed ManaakiNgaTahi `Questionnaire` and `QuestionnaireResponse` profiles as these are not required. A `QuestionnaireResponse` is defined by it's parent `Questionnaire` therefore the profile is not required.
 - Removed unused Questionnaire for MeasureMents consent
 - Updated examples and CapbilityStatement to reflect the above.
 
 
-# v0.1.8 (2023-07-26) Updates to Antiviral Eligibility Questionnaire
+## v0.1.8 (2023-07-26) Updates to Antiviral Eligibility Questionnaire
 
 **AntiViralEligibiltyQuestionnaire**
 - Updated Questionnaire items as per business requirements CFFF-889 and tested form in SDC viewer
@@ -17,7 +21,7 @@
 - Adjusted profile of *ManaakiNgaTahiQuestionnaire* to restore Coding elements required by this questionnaire (which had been excluded)
 - Set start date on period of original (#temp) identifier
 
-# v0.1.7 (2023-07-25) More Questionnaire improvements
+## v0.1.7 (2023-07-25) More Questionnaire improvements
 **New definitional resources**
 1. Created new **Questionnaire** definition resource *COVIDPrivacyStatementQuestionTemplate* based on de facto seed resource in use.
 2. Created new **Questionnaire** definition resource *PrivacyStatementMeasurementCollectionTemplate* based on de facto seed resource in use.
@@ -29,7 +33,7 @@
 - Added an example QuestionnaireResponse to demonstrate a completed *COVIDPrivacyStatementQuestionTemplate* questionnaire
 - Deleted an old example QuestionnaireResponse which was confusing
 
-# v0.1.6 (2023-07-25) More Questionnaire improvements
+## v0.1.6 (2023-07-25) More Questionnaire improvements
 **New definitional resources**
 1. Created new **PlanDefinition** definition resource *COVIDMVPCareplanTemplate* based on similar example resource.
 2. Created new **ActivityDefinition** definition resource *MeasurementProcedureRequestTemplate*, starting with current seed JSON payload in MeasurementProcedureActivityDefinition converted to fsh.
@@ -53,7 +57,7 @@ None.
 **minor**
 - Fixed IG publisher INFO warnings by adding Descriptions to QuestionnaireResponse examples
 
-# v0.1.5 (2023-07-19) COVID Questionnaire improvements
+## v0.1.5 (2023-07-19) COVID Questionnaire improvements
 
 - Revised, and made consistent, canonical identifiers for three COVID-related Questionnaires
   - `COVIDInitialHealthAssessmentQuestionnaire` [was QuestionTemplate-CitC-COVID19-InitialAssessment]
@@ -73,7 +77,7 @@ None.
       Questionnaire at URL:
   https://build.fhir.org/ig/tewhatuora/cinc-fhir-ig/Questionnaire-COVID-PublicHealthHistory
 
-# v0.1.4 (2023-05-01)
+## v0.1.4 (2023-05-01)
 
 - Fixed a number of errors with the build
 - Added `Observation.note` to the Observation resource

--- a/input/fsh/canonical/Questionnaire-AntiViralEligibilityQuestionnaire.fsh
+++ b/input/fsh/canonical/Questionnaire-AntiViralEligibilityQuestionnaire.fsh
@@ -1,7 +1,9 @@
+Alias: $antiviral-eligiblity-whenstarted = https://build.fhir.org/ig/tewhatuora/cinc-fhir-ig/CodeSystem/nz-covid19-antiviraleligiblity-whenstarted-codes
+Alias: $antiviral-eligiblity-situations = https://build.fhir.org/ig/tewhatuora/cinc-fhir-ig/CodeSystem/nz-covid19-antiviraleligiblity-situation-codes
 Alias: $usage-context-type = http://terminology.hl7.org/CodeSystem/usage-context-type
 Alias: $sct = http://snomed.info/sct
+
 Instance: AntiViralEligibilityQuestionnaire
-//InstanceOf: ManaakiNgaTahiQuestionnaire
 InstanceOf: Questionnaire
 Usage: #definition
 * url = "https://build.fhir.org/ig/tewhatuora/cinc-fhir-ig/Questionnaire/AntiViralEligibilityQuestionnaire"
@@ -14,8 +16,7 @@ Usage: #definition
 * identifier[=].period.start = "2023-03-07"
 * identifier[=].period.end = "2023-07-26"
 
-* version = "0.1.8"
-* date = "2023-07-26"
+* date = "2023-01-08"
 * status = #draft
 * experimental = false
 
@@ -57,20 +58,11 @@ Usage: #definition
 * item[=].item.extension.valueCodeableConcept.text = "Help-Button"
 * item[=].item.extension.valueCodeableConcept = http://hl7.org/fhir/questionnaire-item-control#help "Help-Button"
 
-* item[+].text = "Is the patient a COVID-19 case as per the case definition or clinical criteria?"    // v0.1.8
-* item[=].linkId = "COVID19-Positive"
-* item[=].type = #choice
-* item[=].answerOption[0].valueCoding.display = "Yes"
-* item[=].answerOption[+].valueCoding.display = "No"
-* item[=].required = true
 
- // v0.1.8 expanded display text
-* item[=].item.type = #display
-* item[=].item.linkId = "COVID19-Positive_helpText"
-* item[=].item.extension.url = "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl"
-* item[=].item.extension.valueCodeableConcept.text = "Help-Button"
-* item[=].item.extension.valueCodeableConcept = http://hl7.org/fhir/questionnaire-item-control#help "Help-Button"
-* item[=].item.text = """
+// v0.2.0 introduced group so case definition guidance always displays instead of via help button
+* item[+].type = #group
+* item[=].linkId = "case-definition-panel"
+* item[=].text = """CASE DEFINITION
   The transition from PCR to RATs as a primary mode of testing requires the clinical criteria
   to be applied thoughtfully and practically alongside the Case Definition. The case definitions were based upon
   PCR tests being the primary mode of diagnosis and the focus has now changed to clinical decision making based on
@@ -83,29 +75,34 @@ Usage: #definition
   ^For definition see https://www.tewhatuora.govt.nz/for-the-health-sector/covid-19-information-for-health-professionals/case-definition-and-clinical-testing-guidelines-for-covid-19#:~:text=Case%20definitions&text=A%20case%20that%20has%20laboratory,a%20validated%20NAAT%20(PCR)
   """
 
+* item[=].item[0].linkId = "COVID19-Positive"
+* item[=].item[=].text = "Is the patient a COVID-19 case as per the case definition or clinical criteria?"    // v0.1.8
+* item[=].item[=].type = #boolean
+* item[=].item[=].initial.valueBoolean = false
+* item[=].item[=].required = true
+
 * item[+].type = #group
 * item[=].linkId = "criteria-panel"
 * item[=].text = "Does the patient meet the current Pharmac criteria for COVID-19 Antivitals?"
 
 // v0.1.8 item 1 now nested in the group
+// v0.2.0 three options now coded in local codesystem
 * item[=].item[0].text = "1. Symptoms started:"
 * item[=].item[=].linkId = "SymptomsStart"
 * item[=].item[=].type = #choice
+* item[=].item[=].answerValueSet = Canonical(AntiViralEligiblitySymptomsStartedValueSet)  // v0.2.0 three options moved into local codesystem/valueset
 * item[=].item[=].required = true
+
 //* item[=].item[=].enableWhen.question = "COVID19-Positive"  -- v0.1.8 removed conditional
 //* item[=].item[=].enableWhen.operator = #=                  -- v0.1.8 removed conditional
 //* item[=].item[=].enableWhen.answerCoding.display = "Yes"   -- v0.1.8 removed conditional
 //* item[=].item[=].enableBehavior = #all                     -- v0.1.8 removed conditional
-* item[=].item[=].answerOption[0].valueCoding.display = "Within the last 5 days (if considering nirmatrelvir with ritonavir or molnupiravir)"
-* item[=].item[=].answerOption[+].valueCoding.display = "Within the last 7 days (if considering remdesivir)"
-* item[=].item[=].answerOption[+].valueCoding.display = "More than 5 days ago if assessing for nirmaltrelvir with ritonavir; and molnupiravir, OR more than 7 days ago if assessing for remdesivir"   // v0.1.8
+
 
 // v0.1.8 item 2 now nested in the group
 * item[=].item[+].text = "2. My patient requires supplemental oxygen"
 * item[=].item[=].linkId = "supoxygen"
-* item[=].item[=].type = #choice
-* item[=].item[=].answerOption[0].valueCoding.display = "Yes"
-* item[=].item[=].answerOption[+].valueCoding.display = "No"
+* item[=].item[=].type = #boolean
 * item[=].item[=].repeats = false
 * item[=].item[=].required = true
 * item[=].item[=].readOnly = false
@@ -114,19 +111,11 @@ Usage: #definition
 * item[=].item[+].text = "3. My patient's condition or circumstance (choose one):"   // v0.1.8
 * item[=].item[=].linkId = "criteria"
 * item[=].item[=].type = #choice
+* item[=].item[=].answerValueSet = Canonical(AntiViralEligiblitySituationValueSet)  // v0.2.0 choice options moved into local codesystem
 * item[=].item[=].required = true
 * item[=].item[=].repeats = false
-* item[=].item[=].answerOption[0].valueCoding.display = "is immunocompromised[1] and not expected to reliably mount an adequate immune response to COVID-19 vaccination or SARS-CoV-2 infection, regardless of vaccination status"
-* item[=].item[=].answerOption[+].valueCoding.display = "has Down syndrome"
-* item[=].item[=].answerOption[+].valueCoding.display = "has sickle cell disease"
-* item[=].item[=].answerOption[+].valueCoding.display = "has had a previous admission to critical or high dependency care as a result of COVID-19"
-* item[=].item[=].answerOption[+].valueCoding.display = "is 65 years old or older"
-* item[=].item[=].answerOption[+].valueCoding.display = "is 50 years old or older and is of Māori or Pacific ethnicity"
-* item[=].item[=].answerOption[+].valueCoding.display = "is 50 years old or older and has not completed a primary course of vaccination [2]"
-* item[=].item[=].answerOption[+].valueCoding.display = "has 3 or more high-risk conditions, as defined by the Ministry of Health [3]"
-* item[=].item[=].answerOption[+].valueCoding.display = "none of the above"
 
-// v0.1.8 added guidance for 3 of the options
+// v0.1.8 add footnote guidance about some of the options
 * item[=].item[=].item.text = """
   [1]For definition of Ministry of Health criteria of ‘severe immunocompromise’ for third primary dose see: https://www.health.govt.nz/covid-19-novel-coronavirus/covid-19-vaccines/covid-19-vaccine-severely-immunocompromised-people#criteria
   [2]A primary dose for most people is 2 vaccinations
@@ -144,13 +133,13 @@ Usage: #definition
 * item[=].text = "Assessment: No - the patient IS NOT eligible for COVID-19 Antivirals"
 * item[=].enableWhen[0].question = "SymptomsStart"
 * item[=].enableWhen[=].operator = #=
-* item[=].enableWhen[=].answerCoding.display = "More than 5 days ago if assessing for nirmaltrelvir with ritonavir; and molnupiravir, OR more than 7 days ago if assessing for remdesivir"
+* item[=].enableWhen[=].answerCoding.code = $antiviral-eligiblity-whenstarted#not-recent          // v0.2.0
 * item[=].enableWhen[+].question = "criteria"
 * item[=].enableWhen[=].operator = #=
-* item[=].enableWhen[=].answerCoding.display = "none of the above"
+* item[=].enableWhen[=].answerCoding.code = $antiviral-eligiblity-situations#none-of-the-above    // v0.2.0
 * item[=].enableWhen[+].question = "supoxygen"
 * item[=].enableWhen[=].operator = #=
-* item[=].enableWhen[=].answerCoding.display = "Yes"
+* item[=].enableWhen[=].answerBoolean = true
 * item[=].enableBehavior = #any
 * item[=].answerOption.valueCoding.display = "confirm"
 
@@ -160,13 +149,13 @@ Usage: #definition
 * item[=].text = "Assessment: Yes - the patient IS eligible for COVID-19 Antivirals"
 * item[=].enableWhen[0].question = "SymptomsStart"
 * item[=].enableWhen[=].operator = #!=
-* item[=].enableWhen[=].answerCoding.display = "More than 5 days ago if assessing for nirmaltrelvir with ritonavir; and molnupiravir, OR more than 7 days ago if assessing for remdesivir"
+* item[=].enableWhen[=].answerCoding.code = $antiviral-eligiblity-whenstarted#not-recent          // v0.2.0
 * item[=].enableWhen[+].question = "criteria"
 * item[=].enableWhen[=].operator = #!=
-* item[=].enableWhen[=].answerCoding.display = "none of the above"
+* item[=].enableWhen[=].answerCoding.code = $antiviral-eligiblity-situations#none-of-the-above    // v0.2.0 
 * item[=].enableWhen[+].question = "supoxygen"
 * item[=].enableWhen[=].operator = #!=
-* item[=].enableWhen[=].answerCoding.display = "Yes"
+* item[=].enableWhen[=].answerBoolean = true
 * item[=].enableBehavior = #all
 * item[=].answerOption.valueCoding.display = "confirm"
 

--- a/input/fsh/examples/AntiViralEligibilityNoQuestionnaireResponse.fsh
+++ b/input/fsh/examples/AntiViralEligibilityNoQuestionnaireResponse.fsh
@@ -1,15 +1,21 @@
+Alias: $antiviral-eligiblity-whenstarted = https://build.fhir.org/ig/tewhatuora/cinc-fhir-ig/CodeSystem/nz-covid19-antiviraleligiblity-whenstarted-codes
+Alias: $antiviral-eligiblity-situations = https://build.fhir.org/ig/tewhatuora/cinc-fhir-ig/CodeSystem/nz-covid19-antiviraleligiblity-situation-codes
+
 Instance: AntiViralEligibilityNoQuestionnaireResponse
 InstanceOf: QuestionnaireResponse
-Description: "Demonstrating payload for a pharmacy eligibility review where patient not eligible"
+Description: "Demonstrating payload for a pharmacy eligibility review where patient IS NOT eligible"
 Usage: #example
-* status = #completed
-* authored = "2023-07-26T06:15:06.063Z"
+
 * questionnaire = Canonical(AntiViralEligibilityQuestionnaire)
-* subject.type = "Patient"
+* status = #completed
 * subject.identifier.use = #official
 * subject.identifier.system = "https://standards.digital.health.nz/ns/nhi-id"
 * subject.identifier.value = "ZXP7823"
 * subject.display = "Carey Carrington"
+* subject.type = "Patient"
+
+* authored = "2023-07-26T06:15:06.063Z"
+
 * author.type = "Practitioner"
 * author.identifier.use = #official
 * author.identifier.system = "https://standards.digital.health.nz/ns/hpi-person-id"
@@ -24,24 +30,25 @@ Usage: #example
 * item[=].text = "Date Review Performed"
 * item[=].answer.valueDate = "2023-03-27"
 
-* item[+].linkId = "COVID19-Positive"
-* item[=].text = "Is the patient a COVID-19 case as per the case definition or clinical criteria?"
-* item[=].answer.valueCoding.display = "Yes"
+* item[+].linkId = "case-definition-panel"
+* item[=].item[0].linkId = "COVID19-Positive"
+* item[=].item[=].text = "Is the patient a COVID-19 case as per the case definition or clinical criteria?"
+* item[=].item[=].answer.valueBoolean = true
 
 * item[+].linkId = "criteria-panel"
 * item[=].text = "Does the patient meet the current Pharmac criteria for COVID-19 Antivitals?"
 
 * item[=].item[0].linkId = "SymptomsStart"
 * item[=].item[=].text = "1. Symptoms started:"
-* item[=].item[=].answer.valueCoding.display = "More than 7 days ago"
+* item[=].item[=].answer.valueCoding = $antiviral-eligiblity-whenstarted#not-recent
 
 * item[=].item[+].linkId = "supoxygen"
 * item[=].item[=].text = "2. My patient requires supplemental oxygen"
-* item[=].item[=].answer.valueCoding.display = "Yes"
+* item[=].item[=].answer.valueBoolean = true
 
 * item[=].item[+].linkId = "criteria"
 * item[=].item[=].text = "3. My patient's condition or circumstance (choose one):"
-* item[=].item[=].answer.valueCoding.display = "none of the above"
+* item[=].item[=].answer.valueCoding = $antiviral-eligiblity-situations#none-of-the-above
 
 * item[+].linkId = "eligible-no"
 * item[=].text = "Assessment: No - the patient IS NOT eligible for COVID-19 Antivirals"
@@ -70,7 +77,6 @@ Usage: #example
 * item[=].item[+].linkId = "PharmacyAddress"
 * item[=].item[=].text = "Pharmacy address details"
 * item[=].item[=].answer.valueString = "FROM HPI e.g. 133 Molesworth Street, Thorndon 6011, Wellington"
-
 
 * item[+].linkId = "GeneralPracticeInformation"
 * item[=].text = "Please provide details about the patient's general practice"

--- a/input/fsh/examples/AntiViralEligibilityYesQuestionnaireResponse.fsh
+++ b/input/fsh/examples/AntiViralEligibilityYesQuestionnaireResponse.fsh
@@ -1,15 +1,21 @@
+Alias: $antiviral-eligiblity-whenstarted = https://build.fhir.org/ig/tewhatuora/cinc-fhir-ig/CodeSystem/nz-covid19-antiviraleligiblity-whenstarted-codes
+Alias: $antiviral-eligiblity-situations = https://build.fhir.org/ig/tewhatuora/cinc-fhir-ig/CodeSystem/nz-covid19-antiviraleligiblity-situation-codes
+
 Instance: AntiViralEligibilityYesQuestionnaireResponse
 InstanceOf: QuestionnaireResponse
 Description: "Demonstrating payload for a pharmacy eligibility review where patient IS eligible"
 Usage: #example
-* status = #completed
-* authored = "2023-07-26T06:15:06.063Z"
+
 * questionnaire = Canonical(AntiViralEligibilityQuestionnaire)
-* subject.type = "Patient"
+* status = #completed
 * subject.identifier.use = #official
 * subject.identifier.system = "https://standards.digital.health.nz/ns/nhi-id"
 * subject.identifier.value = "ZXP7823"
 * subject.display = "Carey Carrington"
+* subject.type = "Patient"
+
+* authored = "2023-07-26T06:15:06.063Z"
+
 * author.type = "Practitioner"
 * author.identifier.use = #official
 * author.identifier.system = "https://standards.digital.health.nz/ns/hpi-person-id"
@@ -24,24 +30,25 @@ Usage: #example
 * item[=].text = "Date Review Performed"
 * item[=].answer.valueDate = "2023-03-27"
 
-* item[+].linkId = "COVID19-Positive"
-* item[=].text = "Is the patient a COVID-19 case as per the case definition or clinical criteria?"
-* item[=].answer.valueCoding.display = "Yes"
+* item[+].linkId = "case-definition-panel"
+* item[=].item[0].linkId = "COVID19-Positive"
+* item[=].item[=].text = "Is the patient a COVID-19 case as per the case definition or clinical criteria?"
+* item[=].item[=].answer.valueBoolean = true
 
 * item[+].linkId = "criteria-panel"
 * item[=].text = "Does the patient meet the current Pharmac criteria for COVID-19 Antivitals?"
 
 * item[=].item[0].linkId = "SymptomsStart"
 * item[=].item[=].text = "1. Symptoms started:"
-* item[=].item[=].answer.valueCoding.display = "Within the last 7 days (if considering remdesivir)"
+* item[=].item[=].answer.valueCoding = $antiviral-eligiblity-whenstarted#within-seven-days
 
 * item[=].item[+].linkId = "supoxygen"
 * item[=].item[=].text = "2. My patient requires supplemental oxygen"
-* item[=].item[=].answer.valueCoding.display = "No"
+* item[=].item[=].answer.valueBoolean = false
 
 * item[=].item[+].linkId = "criteria"
 * item[=].item[=].text = "3. My patient's condition or circumstance (choose one):"
-* item[=].item[=].answer.valueCoding.display = "has Down syndrome"
+* item[=].item[=].answer.valueCoding = $antiviral-eligiblity-situations#down-syndrome
 
 * item[+].linkId = "eligible-yes"
 * item[=].text = "Assessment: Yes - the patient IS eligible for COVID-19 Antivirals"

--- a/input/fsh/terminology/AntiViralEligibilitySituationCodes.fsh
+++ b/input/fsh/terminology/AntiViralEligibilitySituationCodes.fsh
@@ -1,0 +1,20 @@
+CodeSystem: AntiViralEligibilitySituationCodes
+Id: nz-covid19-antiviraleligiblity-situation-codes
+Title: "Patient situations assessed for antiviral medication"
+Description:  "Each code represents a patient condition or circumstance as assessed for antiviral medication"
+
+* #immunocompromised "Patient is immunocompromised[1] and not expected to reliably mount an adequate immune response to COVID-19 vaccination or SARS-CoV-2 infection, regardless of vaccination status"
+* #down-syndrome "Patient has Down syndrome"
+* #sickle-cell "Patient has sickle cell disease"
+* #covid-prior-admission "Patient has had a previous admission to critical or high dependency care as a result of COVID-19"
+* #sixty-five-plus "Patient is 65 years old or older"
+* #fifty-plus-ethnicity "Patient is 50 years old or older and is of Māori or Pacific ethnicity"
+* #fifty-plus-no-vax "Patient is 50 years old or older and has not completed a primary course of vaccination [2]"
+* #multi-conditions "Patient has three or more high-risk conditions, as defined by the Ministry of Health [3]"
+* #none-of-the-above "None of the above apply to patient"
+
+* ^publisher = "Te Whatu Ora / Health New Zealand"
+* ^experimental = false
+* ^caseSensitive = true
+* ^purpose = "Describes patient conditions and circumstances for assessing eligiblity for antiviral medication."
+* ^status = #draft

--- a/input/fsh/terminology/AntiViralEligibilityWhenSymptomsStartedCodes.fsh
+++ b/input/fsh/terminology/AntiViralEligibilityWhenSymptomsStartedCodes.fsh
@@ -1,0 +1,14 @@
+CodeSystem: AntiViralEligibilityWhenSymptomsStartedCodes
+Id: nz-covid19-antiviraleligiblity-whenstarted-codes
+Title: "Patient-start-of-COVID-symptoms classifiers"
+Description:  "Each code represents a timeframe in which a patient's COVID symptoms started"
+
+* #within-five-days "Within the last 5 days (if considering nirmatrelvir with ritonavir or molnupiravir)"
+* #within-seven-days "Within the last 7 days (if considering remdesivir)"
+* #not-recent "More than 5 days ago if assessing for nirmaltrelvir with ritonavir; and molnupiravir, OR more than 7 days ago if assessing for remdesivir"
+
+* ^publisher = "Te Whatu Ora / Health New Zealand"
+* ^experimental = false
+* ^caseSensitive = true
+* ^purpose = "Classifies timeframe when patient COVID-19 symptoms started"
+* ^status = #draft

--- a/input/fsh/terminology/AntiViralEligiblitySituationValueSet.fsh
+++ b/input/fsh/terminology/AntiViralEligiblitySituationValueSet.fsh
@@ -1,0 +1,6 @@
+ValueSet: AntiViralEligiblitySituationValueSet
+Id: nz-covid19-antiviraleligiblity-situations
+Title: "Classifiers for COVID patient's health conditions/circumstances"
+Description:  "Classifies patient health situation as assessed for antiviral medication eligibility"
+* ^experimental = true
+* include codes from system AntiViralEligibilitySituationCodes

--- a/input/fsh/terminology/AntiViralEligiblitySymptomsStartedValueSet.fsh
+++ b/input/fsh/terminology/AntiViralEligiblitySymptomsStartedValueSet.fsh
@@ -1,0 +1,6 @@
+ValueSet: AntiViralEligiblitySymptomsStartedValueSet
+Id: nz-covid19-antiviraleligiblity-whensymptomsstarted
+Title: "Patient-start-of-COVID-symptoms classifiers"
+Description:  "Classifies start of patient COVID symptoms for antiviral medication eligibility assessment"
+* ^experimental = true
+* include codes from system AntiViralEligibilityWhenSymptomsStartedCodes

--- a/releaseNotes/v0.2.0.md
+++ b/releaseNotes/v0.2.0.md
@@ -5,17 +5,20 @@
 ## Breaking changes to QuestionnaireResponses in this update
 
 Preparation of QuestionnaireResponse payloads must now take into account the following changes with this update to the Questionaire
-1. Items with linkIds _SymptomsStart_, _supoxygen_ and _criteria_ have now become **child items** of the new top-level item _criteria-panel_
+1. Response items with linkIds _SymptomsStart_, _supoxygen_ and _criteria_ have now become **child items** of a new top-level item _criteria-panel_ (The purpose of this panel is to display criteria text to match the CCCM UI)
 
-2. The **valueCoding** answer in item _symptomsStart_  can no longer be a simple string and must now be one of the code from local valueset
-  https://build.fhir.org/ig/tewhatuora/cinc-fhir-ig/CodeSystem/nz-covid19-antiviraleligiblity-whenstarted-codes
+2. Response item _symptomsStart_: the answer must now be a **valuecoding** from the local valueset.  A `valueCoding.display` string is no longer acceptable.
+  ValueSet: https://build.fhir.org/ig/tewhatuora/cinc-fhir-ig/CodeSystem/nz-covid19-antiviraleligiblity-whenstarted-codes
 
-3. The **valueCoding** answer in item _criteria_  can no longer be a simple string and must be one of the codes from local valueset
-  https://build.fhir.org/ig/tewhatuora/cinc-fhir-ig/CodeSystem/nz-covid19-antiviraleligiblity-situation-codes
+3. Response item _criteria_: the answer must now be a **valuecoding** from the local valueset.  A `valueCoding.display` string is no longer acceptable.
+  ValueSet: https://build.fhir.org/ig/tewhatuora/cinc-fhir-ig/CodeSystem/nz-covid19-antiviraleligiblity-situation-codes
 
+4. Response item _COVID19-Positive_, which asserts whether a patient meets the case definition, is now a **child item** of a new top-level item _case-definition-panel_ (The purpose of this panel is to display Case Definition guidance instead of this being accessed through a help button)
 
 ### Other notes
 4. As of IG v0.2.0 clients must set `questionnaire` element in these responses to the *canonical URL* of the Questionnaire
   https://build.fhir.org/ig/tewhatuora/cinc-fhir-ig/Questionnaire/AntiViralEligibilityQuestionnaire
 
 5. The IG now defines QuestionnaireResponse examples to be `InstanceOf: QuestionnaireResponse` instead of `InstanceOf: ManaakiNgaTahiQuestionnaireResponse` but clients will not see any changes when preparing responses.
+
+6. Several updates have been to item text / help text to match CCCM.

--- a/releaseNotes/v0.2.0.md
+++ b/releaseNotes/v0.2.0.md
@@ -1,0 +1,21 @@
+# CINC FHIR Implementation Guide v0.2.0
+
+## https://build.fhir.org/ig/tewhatuora/cinc-fhir-ig/Questionnaire/AntiViralEligibilityQuestionnaire
+
+## Breaking changes to QuestionnaireResponses in this update
+
+Preparation of QuestionnaireResponse payloads must now take into account the following changes with this update to the Questionaire
+1. Items with linkIds _SymptomsStart_, _supoxygen_ and _criteria_ have now become **child items** of the new top-level item _criteria-panel_
+
+2. The **valueCoding** answer in item _symptomsStart_  can no longer be a simple string and must now be one of the code from local valueset
+  https://build.fhir.org/ig/tewhatuora/cinc-fhir-ig/CodeSystem/nz-covid19-antiviraleligiblity-whenstarted-codes
+
+3. The **valueCoding** answer in item _criteria_  can no longer be a simple string and must be one of the codes from local valueset
+  https://build.fhir.org/ig/tewhatuora/cinc-fhir-ig/CodeSystem/nz-covid19-antiviraleligiblity-situation-codes
+
+
+### Other notes
+4. As of IG v0.2.0 clients must set `questionnaire` element in these responses to the *canonical URL* of the Questionnaire
+  https://build.fhir.org/ig/tewhatuora/cinc-fhir-ig/Questionnaire/AntiViralEligibilityQuestionnaire
+
+5. The IG now defines QuestionnaireResponse examples to be `InstanceOf: QuestionnaireResponse` instead of `InstanceOf: ManaakiNgaTahiQuestionnaireResponse` but clients will not see any changes when preparing responses.

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -9,7 +9,7 @@ name: CINC_FHIR_IG
 title: Care In The Community FHIR API
 description: Care In The Community FHIR API
 status: draft
-version: 0.1.9
+version: 0.2.0
 fhirVersion: 4.0.1
 copyrightYear: 2022+
 releaseLabel: ci-build # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use


### PR DESCRIPTION
This comprises the changes requested in ticket CFFF-889 plus a couple of other refinements notably the definition of two local ValueSets/CodeSets for the coded answers.  There will be several breaking changes for clients already posting QuestionnaireResponses so I have detailed these in a release note which we can send to AbleTech and Valentia.

Once this branch is merged I will submit another PR with all the other assorted fixes and changes to the IG which were previously mixed in with this update.