### PR TITLE
IMS-3378

### DIFF
--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -68,29 +68,37 @@ Alias: $hnz-service-request-status-reason-codes = https://fhir-ig.digital.health
 
 //----Dunedin Hospital Outpatients----//
 
-// ValueSets
-Alias: $vs-administrative-gender = http://hl7.org/fhir/ValueSet/administrative-gender
-Alias: $vs-patient-contact-relationship = http://terminology.hl7.org/ValueSet/v3-PersonalRelationshipRoleType|3.0.0
-Alias: $vs-ethnic-group-level-4-code = https://nzhts.digital.health.nz/fhir/ValueSet/ethnic-group-level-4-code|2.1.0
-Alias: $vs-encounter-status = http://hl7.org/fhir/ValueSet/encounter-status
-
 // StructureDefinitions
+Alias: $sd-birthPlace = http://hl7.org.nz/fhir/StructureDefinition/birth-place
 Alias: $sd-building-name = http://hl7.org.nz/fhir/StructureDefinition/building-name
+Alias: $sd-ethnicity = http://hl7.org.nz/fhir/StructureDefinition/nz-ethnicity
 Alias: $sd-interpreter-required  = http://hl7.org/fhir/StructureDefinition/patient-interpreterRequired|5.2.0
+Alias: $sd-nzResidency = http://hl7.org.nz/fhir/StructureDefinition/nz-residency
+Alias: $sd-nzCitizen = http://hl7.org.nz/fhir/StructureDefinition/nz-citizenship
 Alias: $sd-patient-contact-role-extension-id = https://fhir-ig.digital.health.nz/shared-care/StructureDefinition/dho-patient-contact-role-extension-id
-Alias: $sd-suburb = http://hl7.org.nz/fhir/StructureDefinition/suburb
 Alias: $sd-sex-at-birth = http://hl7.org.nz/fhir/StructureDefinition/sex-at-birth
+Alias: $sd-suburb = http://hl7.org.nz/fhir/StructureDefinition/suburb
+Alias: $sd-preferred = http://hl7.org/fhir/StructureDefinition/iso21090-preferred
+Alias: $sd-information-source = http://hl7.org.nz/fhir/StructureDefinition/information-source
 
 // Taxonomies
+Alias: $cs-nc-health-specialty-code = http://nzhts.digital.health.nz/fhir/CodeSystem/nc-health-specialty-codes
+Alias: $cs-patient-contact-role = https://fhir-ig.digital.health.nz/shared-care/CodeSystem/cs-patient-contact-role
 Alias: $ns-domicile-code = https://standards.digital.health.nz/ns/domicile-code
 Alias: $ns-ethnic-group-level-4-code = https://standards.digital.health.nz/ns/ethnic-group-level-4-code
+Alias: $ns-hpi-person-id = https://standards.digital.health.nz/ns/hpi-person-id
 Alias: $ns-information-source-code = https://standards.digital.health.nz/ns/information-source-code
 Alias: $ns-nz-citizenship-status-code = https://standards.digital.health.nz/ns/nz-citizenship-status-code
-Alias: $ns-hpi-person-id = https://standards.digital.health.nz/ns/hpi-person-id
-// This does not appear to exist despite the documentation.
-//Alias: $ns-nz-residency-code = https://standards.digital.health.nz/ns/nz-residency-code
-Alias: $cs-patient-contact-role = https://fhir-ig.digital.health.nz/shared-care/CodeSystem/cs-patient-contact-role
-Alias: $cs-nc-health-specialty-code = http://nzhts.digital.health.nz/fhir/CodeSystem/nc-health-specialty-codes
+
+// ValueSets
+Alias: $vs-administrative-gender = http://hl7.org/fhir/ValueSet/administrative-gender
+Alias: $vs-encounter-status = http://hl7.org/fhir/ValueSet/encounter-status
+Alias: $vs-ethnic-group-level-4-code = https://nzhts.digital.health.nz/fhir/ValueSet/ethnic-group-level-4-code|2.1.0
+Alias: $vs-patient-contact-relationship = http://terminology.hl7.org/ValueSet/v3-PersonalRelationshipRoleType|3.0.0
+Alias: $vs-nz-citizenship-information-source-code = https://nzhts.digital.health.nz/fhir/ValueSet/nz-citizenship-source-code
+Alias: $vs-name-prefix = https://nzhts.digital.health.nz/fhir/ValueSet/name-prefix-code
+Alias: $vs-name-suffix = https://nzhts.digital.health.nz/fhir/ValueSet/name-suffix-code
+Alias: $vs-name-information-source = https://nzhts.digital.health.nz/fhir/ValueSet/name-source-code
 
 //----End of Dunedin Hospital Outpatients----//
 

--- a/input/fsh/capabilities/capabilitystatement.fsh
+++ b/input/fsh/capabilities/capabilitystatement.fsh
@@ -269,7 +269,21 @@ Usage: #definition
 * rest.resource[=].supportedProfile[+] = Canonical(DHOEncounter)
 * rest.resource[=].supportedProfile[+] = Canonical(DHOEncounterCreate)
 * rest.resource[=].supportedProfile[+] = Canonical(DHOEncounterUpdate)
-* rest.resource[=] insert GenericCRUDInteractions
+// replaced "* rest.resource[=] insert GenericCRUDInteractions" with the following to allow history and conditional updates
+* rest.resource[=].interaction[0].code = #create
+* rest.resource[=].interaction[+].code = #read
+* rest.resource[=].interaction[+].code = #update
+* rest.resource[=].interaction[+].code = #delete
+* rest.resource[=].interaction[+].code = #vread
+* rest.resource[=].interaction[+].code = #search-type
+* rest.resource[=].versioning = #versioned
+* rest.resource[=].readHistory = true
+* rest.resource[=].updateCreate = false
+* rest.resource[=].conditionalCreate = false
+* rest.resource[=].conditionalRead = #not-supported
+* rest.resource[=].conditionalUpdate = true
+* rest.resource[=].conditionalDelete = #not-supported
+// end
 * rest.resource[=].searchInclude[+] = "*"
 * rest.resource[=].searchInclude[+] = "Encounter:diagnosis"
 * rest.resource[=].searchInclude[+] = "Encounter:appointment"

--- a/input/fsh/capabilities/capabilitystatement.fsh
+++ b/input/fsh/capabilities/capabilitystatement.fsh
@@ -269,21 +269,7 @@ Usage: #definition
 * rest.resource[=].supportedProfile[+] = Canonical(DHOEncounter)
 * rest.resource[=].supportedProfile[+] = Canonical(DHOEncounterCreate)
 * rest.resource[=].supportedProfile[+] = Canonical(DHOEncounterUpdate)
-// replaced "* rest.resource[=] insert GenericCRUDInteractions" with the following to allow history and conditional updates
-* rest.resource[=].interaction[0].code = #create
-* rest.resource[=].interaction[+].code = #read
-* rest.resource[=].interaction[+].code = #update
-* rest.resource[=].interaction[+].code = #delete
-* rest.resource[=].interaction[+].code = #vread
-* rest.resource[=].interaction[+].code = #search-type
-* rest.resource[=].versioning = #versioned
-* rest.resource[=].readHistory = true
-* rest.resource[=].updateCreate = false
-* rest.resource[=].conditionalCreate = false
-* rest.resource[=].conditionalRead = #not-supported
-* rest.resource[=].conditionalUpdate = true
-* rest.resource[=].conditionalDelete = #not-supported
-// end
+* rest.resource[=] insert GenericCRUDInteractions
 * rest.resource[=].searchInclude[+] = "*"
 * rest.resource[=].searchInclude[+] = "Encounter:diagnosis"
 * rest.resource[=].searchInclude[+] = "Encounter:appointment"

--- a/input/fsh/examples/cinc/DHOPatientExample.fsh
+++ b/input/fsh/examples/cinc/DHOPatientExample.fsh
@@ -1,28 +1,164 @@
-Instance: DHOPractitionerRole2
+Instance: DHOPractitionerRole1
 InstanceOf: PractitionerRole
-Description: "Practitioner Role for test Patient"
+Description: "Practitioner Role for test Patient - General Practitioner"
 Usage: #inline
+* code.coding[0].system = $sct
+* code.coding[0].code = #309394004
+* code.coding[0].display = "General Practitioner"
 * practitioner.type = #Practitioner
-* practitioner.identifier.system = "https://standards.digital.health.nz/id/hpi-person-id"
+* practitioner.identifier.system = "https://standards.digital.health.nz/ns/hpi-person-id"
 * practitioner.identifier.value = "99ZZZX"
 * practitioner.display = "Dr Dotty McStuffins"
-
 * organization.type = #Organization
-* organization.identifier.system = "https://standards.digital.health.nz/id/hpi-organisation-id"
+* organization.identifier.system = "https://standards.digital.health.nz/ns/hpi-organisation-id"
 * organization.identifier.value = "G00001-E"
 * organization.display = "HealthIsUs"
-
 * location.type = #Location
-* location.identifier.system = "https://standards.digital.health.nz/id/hpi-facility-d"
+* location.identifier.system = "https://standards.digital.health.nz/ns/hpi-facility-id"
 * location.identifier.value = "F04066-D"
 * location.display = "Good Health Medical Centre"
 
-Instance: DHOPatientExample
+Instance: DHOPractitionerRole2
+InstanceOf: PractitionerRole
+Description: "Practitioner Role for test Patient - Nurse Practitioner - Florence Nightingale"
+Usage: #inline
+* code.coding[0].system = $sct
+* code.coding[0].code = #224571005
+* code.coding[0].display = "Nurse Practitioner"
+* practitioner.type = #Practitioner
+* practitioner.identifier.system = "https://standards.digital.health.nz/ns/hpi-person-id"
+* practitioner.identifier.value = "98ZZZX"
+* practitioner.display = "Florence Nightingale"
+* organization.type = #Organization
+* organization.identifier.system = "https://standards.digital.health.nz/ns/hpi-organisation-id"
+* organization.identifier.value = "G00001-E"
+* organization.display = "HealthIsUs"
+* location.type = #Location
+* location.identifier.system = "https://standards.digital.health.nz/ns/hpi-facility-id"
+* location.identifier.value = "F04066-D"
+* location.display = "Good Health Medical Centre"
+
+Instance: DHOPractitionerRole3
+InstanceOf: PractitionerRole
+Description: "Practitioner Role for test Patient - Nurse Practitioner - Whaea Putiputi"
+Usage: #inline
+* code.coding[0].system = $sct
+* code.coding[0].code = #224571005
+* code.coding[0].display = "Nurse Practitioner"
+* practitioner.type = #Practitioner
+* practitioner.identifier.system = "https://standards.digital.health.nz/ns/hpi-person-id"
+* practitioner.identifier.value = "97ZZZX"
+* practitioner.display = "Whaea Putiputi"
+* organization.type = #Organization
+* organization.identifier.system = "https://standards.digital.health.nz/ns/hpi-organisation-id"
+* organization.identifier.value = "G00001-E"
+* organization.display = "HealthIsUs"
+* location.type = #Location
+* location.identifier.system = "https://standards.digital.health.nz/ns/hpi-facility-id"
+* location.identifier.value = "F04066-D"
+* location.display = "Good Health Medical Centre"
+
+Instance: DHOPatientExampleGP
 InstanceOf: DHOPatient
-Description: "An example Dunedin Hospital Outpatient"
+Description: "An example Dunedin Hospital Outpatient with a GP"
 Usage: #example
 
-* id = "DHO-outpatient-instance"
+* id = "DHO-outpatient-instance-gp"
+* meta.versionId = "1"
+* meta.lastUpdated = "2025-09-04T09:00:00.000Z"
+* meta.profile = "https://fhir-ig.digital.health.nz/shared-care/StructureDefinition/DHOPatient"
+* meta.source = "https://standards.digital.health.nz/ns/hpi-facility-id/F04066-D"
+* insert CorrelationIdTag(xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
+
+* extension[sex-at-birth].valueCodeableConcept.coding.version = "4.0.1"
+* extension[sex-at-birth].valueCodeableConcept.coding.system = "http://hl7.org/fhir/administrative-gender"
+* extension[sex-at-birth].valueCodeableConcept = #female
+
+* extension[ethnicity].valueCodeableConcept.coding.version = "2.0"
+* extension[ethnicity].valueCodeableConcept.coding = $ns-ethnic-group-level-4-code#21111 "Māori"
+* extension[ethnicity].valueCodeableConcept.text = "Māori"
+* extension[nz-citizenship].extension[+].url = "source"
+* extension[nz-citizenship].extension[=].valueCodeableConcept.coding.version = "1.0.0"
+* extension[nz-citizenship].extension[=].valueCodeableConcept.coding = $ns-information-source-code#BREG "Birth Register"
+* extension[nz-citizenship].extension[=].valueCodeableConcept.text = "Birth Register"
+* extension[nz-citizenship].extension[+].url = "status"
+* extension[nz-citizenship].extension[=].valueCodeableConcept.coding.version = "1.1.0"
+* extension[nz-citizenship].extension[=].valueCodeableConcept.coding = $ns-nz-citizenship-status-code#no "No"
+* extension[nz-citizenship].extension[=].valueCodeableConcept.text = "No"
+* extension[interpreter-required].valueBoolean = false
+
+* contained[GP] = DHOPractitionerRole1
+
+* identifier insert NHIIdentifier(ZXP7823)
+* active = true
+* name.use = #usual
+* name.text = "Miss Carey Mary Carrington"
+* name.family = "Carrington"
+* name.given[+] = "Carey"
+* name.given[+] = "Mary"
+* name.prefix = "Miss"
+* telecom[+].system = #phone
+* telecom[=].value = "+64 21 123 4567"
+* telecom[=].use = #mobile
+* telecom[=].rank = 1
+* telecom[=].extension[notification-enabled].valueBoolean = true
+* telecom[+].system = #email
+* telecom[=].value = "example@mail.com"
+* telecom[=].use = #home
+* telecom[=].rank = 2
+* telecom[=].extension[notification-enabled].valueBoolean = true
+* gender = #female
+* birthDate = "1968-01-27"
+* address[+].type = #postal
+* address[=].extension[+].url = "http://hl7.org.nz/fhir/StructureDefinition/domicile-code"
+* address[=].extension[=].valueCodeableConcept.text = "Dunedin Central"
+* address[=].extension[+].url = "http://hl7.org.nz/fhir/StructureDefinition/suburb"
+* address[=].extension[=].valueString = "Dunedin"
+* address[=].line = "360 Cumberland Street"
+* address[=].postalCode = "9016"
+* address[=].country = "NEW ZEALAND"
+* address[=].use = #work
+* address[+].type = #physical
+* address[=].extension[+].url = "http://hl7.org.nz/fhir/StructureDefinition/domicile-code"
+* address[=].extension[=].valueCodeableConcept = $ns-domicile-code#2898 "Maori Hill"
+* address[=].extension[=].valueCodeableConcept.text = "Maori Hill"
+* address[=].extension[+].url = "http://hl7.org.nz/fhir/StructureDefinition/suburb"
+* address[=].extension[=].valueString = "Maori Hill"
+* address[=].line = "481 Highgate"
+* address[=].postalCode = "9010"
+* address[=].country = "NEW ZEALAND"
+* address[=].use = #home
+* maritalStatus.coding[+].code = #S
+* maritalStatus.coding[=].system = "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus"
+* maritalStatus.coding[=].display = "Never Married"
+* contact[+].name.text = "John NextOfKin"
+* contact[=].name.family = "NextOfKin"
+* contact[=].name.given = "John Test"
+* contact[=].telecom[+].system = #phone
+* contact[=].telecom[=].use = #mobile
+* contact[=].telecom[=].value = "+64 27 123 4567"
+* contact[=].extension[+].url = Canonical(dho-patient-contact-role-extension-id)
+* contact[=].extension[=].valueCodeableConcept = $cs-patient-contact-role#nok "Next of Kin"
+* contact[=].extension[=].valueCodeableConcept.text = "Next of Kin"
+
+* contact[+].name.text = "Mary PowerOfAttorney"
+* contact[=].name.family = "PowerOfAttorney"
+* contact[=].name.given = "Mary"
+* contact[=].telecom[+].system = #phone
+* contact[=].telecom[=].use = #mobile
+* contact[=].telecom[=].value = "+64 22 123 4567"
+* contact[=].extension[+].url = Canonical(dho-patient-contact-role-extension-id)
+* contact[=].extension[=].valueCodeableConcept = $cs-patient-contact-role#powatt "Power of Attorney"
+* contact[=].extension[=].valueCodeableConcept.text = "Power of Attorney"
+
+* generalPractitioner[+] = Reference(DHOPractitionerRole1)
+
+Instance: DHOPatientExampleNP
+InstanceOf: DHOPatient
+Description: "An example Dunedin Hospital Outpatient with a Nurse Practitioner"
+Usage: #example
+
+* id = "DHO-outpatient-instance-np"
 * meta.versionId = "1"
 * meta.lastUpdated = "2025-09-04T09:00:00.000Z"
 * meta.profile = "https://fhir-ig.digital.health.nz/shared-care/StructureDefinition/DHOPatient"
@@ -110,13 +246,106 @@ Usage: #example
 * contact[=].extension[=].valueCodeableConcept = $cs-patient-contact-role#powatt "Power of Attorney"
 * contact[=].extension[=].valueCodeableConcept.text = "Power of Attorney"
 
-//* generalPractitioner.type = #Practitioner
-//* generalPractitioner.identifier.use = #official
-//* generalPractitioner.identifier.system = "https://standards.digital.health.nz/ns/hpi-person-id"
-//* generalPractitioner.identifier.value = "99ZZFX"
-//* generalPractitioner.display = "Dottie McStuffins"
-* generalPractitioner.reference = "#DHOPractitionerRole2"
+* generalPractitioner[+] = Reference(DHOPractitionerRole2)
 
+Instance: DHOPatientExampleMultiplePractitioners
+InstanceOf: DHOPatient
+Description: "An example Dunedin Hospital Outpatient with a Multiple Practitioners"
+Usage: #example
+
+* id = "DHO-outpatient-instance-multiple-gp"
+* meta.versionId = "1"
+* meta.lastUpdated = "2025-09-04T09:00:00.000Z"
+* meta.profile = "https://fhir-ig.digital.health.nz/shared-care/StructureDefinition/DHOPatient"
+* meta.source = "https://standards.digital.health.nz/ns/hpi-facility-id/F04066-D"
+* insert CorrelationIdTag(xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
+
+* extension[sex-at-birth].valueCodeableConcept.coding.version = "4.0.1"
+* extension[sex-at-birth].valueCodeableConcept.coding.system = "http://hl7.org/fhir/administrative-gender"
+* extension[sex-at-birth].valueCodeableConcept = #female
+
+* extension[ethnicity].valueCodeableConcept.coding.version = "2.0"
+* extension[ethnicity].valueCodeableConcept.coding = $ns-ethnic-group-level-4-code#21111 "Māori"
+* extension[ethnicity].valueCodeableConcept.text = "Māori"
+* extension[nz-citizenship].extension[+].url = "source"
+* extension[nz-citizenship].extension[=].valueCodeableConcept.coding.version = "1.0.0"
+* extension[nz-citizenship].extension[=].valueCodeableConcept.coding = $ns-information-source-code#BREG "Birth Register"
+* extension[nz-citizenship].extension[=].valueCodeableConcept.text = "Birth Register"
+* extension[nz-citizenship].extension[+].url = "status"
+* extension[nz-citizenship].extension[=].valueCodeableConcept.coding.version = "1.1.0"
+* extension[nz-citizenship].extension[=].valueCodeableConcept.coding = $ns-nz-citizenship-status-code#no "No"
+* extension[nz-citizenship].extension[=].valueCodeableConcept.text = "No"
+* extension[interpreter-required].valueBoolean = false
+
+* contained[GP][+] = DHOPractitionerRole1
+* contained[GP][+] = DHOPractitionerRole2
+* contained[GP][+] = DHOPractitionerRole3
+
+* identifier insert NHIIdentifier(ZXP7823)
+* active = true
+* name.use = #usual
+* name.text = "Miss Carey Mary Carrington"
+* name.family = "Carrington"
+* name.given[+] = "Carey"
+* name.given[+] = "Mary"
+* name.prefix = "Miss"
+* telecom[+].system = #phone
+* telecom[=].value = "+64 21 123 4567"
+* telecom[=].use = #mobile
+* telecom[=].rank = 1
+* telecom[=].extension[notification-enabled].valueBoolean = true
+* telecom[+].system = #email
+* telecom[=].value = "example@mail.com"
+* telecom[=].use = #home
+* telecom[=].rank = 2
+* telecom[=].extension[notification-enabled].valueBoolean = true
+* gender = #female
+* birthDate = "1968-01-27"
+* address[+].type = #postal
+* address[=].extension[+].url = "http://hl7.org.nz/fhir/StructureDefinition/domicile-code"
+* address[=].extension[=].valueCodeableConcept.text = "Dunedin Central"
+* address[=].extension[+].url = "http://hl7.org.nz/fhir/StructureDefinition/suburb"
+* address[=].extension[=].valueString = "Dunedin"
+* address[=].line = "360 Cumberland Street"
+* address[=].postalCode = "9016"
+* address[=].country = "NEW ZEALAND"
+* address[=].use = #work
+* address[+].type = #physical
+* address[=].extension[+].url = "http://hl7.org.nz/fhir/StructureDefinition/domicile-code"
+* address[=].extension[=].valueCodeableConcept = $ns-domicile-code#2898 "Maori Hill"
+* address[=].extension[=].valueCodeableConcept.text = "Maori Hill"
+* address[=].extension[+].url = "http://hl7.org.nz/fhir/StructureDefinition/suburb"
+* address[=].extension[=].valueString = "Maori Hill"
+* address[=].line = "481 Highgate"
+* address[=].postalCode = "9010"
+* address[=].country = "NEW ZEALAND"
+* address[=].use = #home
+* maritalStatus.coding[+].code = #S
+* maritalStatus.coding[=].system = "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus"
+* maritalStatus.coding[=].display = "Never Married"
+* contact[+].name.text = "John NextOfKin"
+* contact[=].name.family = "NextOfKin"
+* contact[=].name.given = "John Test"
+* contact[=].telecom[+].system = #phone
+* contact[=].telecom[=].use = #mobile
+* contact[=].telecom[=].value = "+64 27 123 4567"
+* contact[=].extension[+].url = Canonical(dho-patient-contact-role-extension-id)
+* contact[=].extension[=].valueCodeableConcept = $cs-patient-contact-role#nok "Next of Kin"
+* contact[=].extension[=].valueCodeableConcept.text = "Next of Kin"
+
+* contact[+].name.text = "Mary PowerOfAttorney"
+* contact[=].name.family = "PowerOfAttorney"
+* contact[=].name.given = "Mary"
+* contact[=].telecom[+].system = #phone
+* contact[=].telecom[=].use = #mobile
+* contact[=].telecom[=].value = "+64 22 123 4567"
+* contact[=].extension[+].url = Canonical(dho-patient-contact-role-extension-id)
+* contact[=].extension[=].valueCodeableConcept = $cs-patient-contact-role#powatt "Power of Attorney"
+* contact[=].extension[=].valueCodeableConcept.text = "Power of Attorney"
+
+* generalPractitioner[+] = Reference(DHOPractitionerRole1)
+* generalPractitioner[+] = Reference(DHOPractitionerRole2)
+* generalPractitioner[+] = Reference(DHOPractitionerRole3)
 
 Instance: DHOPatientUpdateExample
 InstanceOf: DHOPatientUpdate

--- a/input/fsh/examples/cinc/DHOPatientExample.fsh
+++ b/input/fsh/examples/cinc/DHOPatientExample.fsh
@@ -1,7 +1,29 @@
+Instance: DHOPractitionerRole2
+InstanceOf: PractitionerRole
+Description: "Practitioner Role for test Patient"
+Usage: #inline
+* practitioner.type = #Practitioner
+* practitioner.identifier.system = "https://standards.digital.health.nz/id/hpi-person-id"
+* practitioner.identifier.value = "99ZZZX"
+* practitioner.display = "Dr Dotty McStuffins"
+
+* organization.type = #Organization
+* organization.identifier.system = "https://standards.digital.health.nz/id/hpi-organisation-id"
+* organization.identifier.value = "G00001-E"
+* organization.display = "HealthIsUs"
+
+* location.type = #Location
+* location.identifier.system = "https://standards.digital.health.nz/id/hpi-facility-d"
+* location.identifier.value = "F04066-D"
+* location.display = "Good Health Medical Centre"
+
 Instance: DHOPatientExample
 InstanceOf: DHOPatient
 Description: "An example Dunedin Hospital Outpatient"
 Usage: #example
+
+* text.div = "<div xmlns='http://www.w3.org/1999/xhtml'>Shows a usual Dunedin Hospital Outpatient with a GP as a Contained resource</div>"
+* text.status = #additional
 
 * id = "DHO-outpatient-instance"
 * meta.versionId = "1"
@@ -26,6 +48,8 @@ Usage: #example
 * extension[nz-citizenship].extension[=].valueCodeableConcept.coding = $ns-nz-citizenship-status-code#no "No"
 * extension[nz-citizenship].extension[=].valueCodeableConcept.text = "No"
 * extension[interpreter-required].valueBoolean = false
+
+* contained[GP] = DHOPractitionerRole2
 
 * identifier insert NHIIdentifier(ZXP7823)
 * active = true
@@ -89,11 +113,13 @@ Usage: #example
 * contact[=].extension[=].valueCodeableConcept = $cs-patient-contact-role#powatt "Power of Attorney"
 * contact[=].extension[=].valueCodeableConcept.text = "Power of Attorney"
 
-* generalPractitioner.type = #Practitioner
-* generalPractitioner.identifier.use = #official
-* generalPractitioner.identifier.system = "https://standards.digital.health.nz/ns/hpi-person-id"
-* generalPractitioner.identifier.value = "99ZZFX"
-* generalPractitioner.display = "Dottie McStuffins"
+//* generalPractitioner.type = #Practitioner
+//* generalPractitioner.identifier.use = #official
+//* generalPractitioner.identifier.system = "https://standards.digital.health.nz/ns/hpi-person-id"
+//* generalPractitioner.identifier.value = "99ZZFX"
+//* generalPractitioner.display = "Dottie McStuffins"
+* generalPractitioner.reference = "#DHOPractitionerRole2"
+
 
 Instance: DHOPatientUpdateExample
 InstanceOf: DHOPatientUpdate

--- a/input/fsh/examples/cinc/DHOPatientExample.fsh
+++ b/input/fsh/examples/cinc/DHOPatientExample.fsh
@@ -22,9 +22,6 @@ InstanceOf: DHOPatient
 Description: "An example Dunedin Hospital Outpatient"
 Usage: #example
 
-* text.div = "<div xmlns='http://www.w3.org/1999/xhtml'>Shows a usual Dunedin Hospital Outpatient with a GP as a Contained resource</div>"
-* text.status = #additional
-
 * id = "DHO-outpatient-instance"
 * meta.versionId = "1"
 * meta.lastUpdated = "2025-09-04T09:00:00.000Z"

--- a/input/fsh/profiles/DHOPatient.fsh
+++ b/input/fsh/profiles/DHOPatient.fsh
@@ -2,8 +2,6 @@ RuleSet: CommonPatientConstraints
 
 * ^status = #active
 * ^jurisdiction = urn:iso:std:iso:3166#NZ
-* ^text.status = #additional
-* ^text.div = "<div xmlns='http://www.w3.org/1999/xhtml'>DHO Patient profile</div>"
 
 // ---------------------------------------------------------
 // Inserts

--- a/input/fsh/profiles/DHOPatient.fsh
+++ b/input/fsh/profiles/DHOPatient.fsh
@@ -2,6 +2,8 @@ RuleSet: CommonPatientConstraints
 
 * ^status = #active
 * ^jurisdiction = urn:iso:std:iso:3166#NZ
+* ^text.status = #additional
+* ^text.div = "<div xmlns='http://www.w3.org/1999/xhtml'>DHO Patient profile</div>"
 
 // ---------------------------------------------------------
 // Inserts
@@ -17,8 +19,13 @@ RuleSet: CommonPatientConstraints
 // ---------------------------------------------------------
 // Extensions
 // ---------------------------------------------------------
-* extension contains $sd-interpreter-required named interpreter-required 0..1
-* extension[nzCitizen] ^short = "Is this person a New Zealand citizen"
+* extension contains  $sd-interpreter-required named interpreter-required 0..1
+
+* extension[ethnicity].valueCodeableConcept from $vs-ethnic-group-level-4-code (required)
+
+* extension[nzCitizen] ^short = "This field indicates New Zealand citizenship status of the patient"
+* extension[nzCitizen] ^definition = "This field is used to indicate the New Zealand citizenship status of the patient"
+* extension[nzCitizen].extension[source].valueCodeableConcept from $vs-nz-citizenship-information-source-code
 
 // ---------------------------------------------------------
 // Cardinality tightening
@@ -28,7 +35,7 @@ RuleSet: CommonPatientConstraints
 * communication 0..0
 * managingOrganization 0..0
 * link 0..0
-* contained 0..0
+* contained 0..1
 * implicitRules 0..0
 * language 0..0
 // If you look at the definition of a FHIR patient (https://www.hl7.org/fhir/patient.html), deceased[x] is a a choice of data types
@@ -56,12 +63,14 @@ Description: "This profile derives from the [Patient](https://hl7.org/fhir/R4B/p
 // ---------------------------------------------------------
 * name 1..* MS
   * use 1..1 MS
-    * ^short = "one of: usual / old"
+    * ^short = "usual | temp | nickname | maiden"
   * family 1..1 MS
-  * given MS
-  * prefix MS
+  * given 0..5 MS
+    * ^short = "Given name and other given name(s)"
+    * ^definition = "Given name and other given name(s) for the patient"
+  * prefix from $vs-name-prefix
   * suffix 0..0
-  * extension 0..0
+  * extension contains $sd-preferred named preferred 0..1
   * id 0..0
 * telecom 0..* MS
   * obeys dho-telecom-notification-valid-system
@@ -125,12 +134,36 @@ Description: "This profile derives from the [Patient](https://hl7.org/fhir/R4B/p
   * organization 0..0
   * period 0..1 MS
   * id 0..0
-* extension[ethnicity] 0..*
 
 // ---------------------------------------------------------
 // Reference constraints
 // ---------------------------------------------------------
-* generalPractitioner only Reference(NzOrganization or NzPractitioner or NzPractitionerRole)
+// * generalPractitioner only Reference(NzOrganization or NzPractitioner or NzPractitionerRole)
+// GP
+
+//Limit the possible resources for generalPractitioner only to a PractitionerRole
+//Note that this might still be a contained resource - that's still supported by this profile
+* generalPractitioner only Reference(PractitionerRole)
+
+* generalPractitioner 0..1
+* generalPractitioner ^short = "Reference for the Patient's enrolled general Practitioner"
+* generalPractitioner ^definition = "The reference for the General Practice that the patient is enrolled with"
+
+// slice for contained practitionerRole
+* contained ^slicing.discriminator.type = #type
+* contained ^slicing.discriminator.path = "$this"
+* contained ^slicing.rules = #closed
+* contained ^slicing.description = "Slicing to specify a PractitionerRole resource may be returned as a contained resource for the Patient's General Practitioner information"
+* contained contains GP 0..1
+* contained[GP] only http://hl7.org/fhir/StructureDefinition/PractitionerRole
+* contained[GP] ^short = "Contained resource for the Patient's enrolled general Practitioner"
+* contained[GP] ^definition = "Contained resource for the General Practice that the patient is enrolled with"
+* obeys dho-nz-pat-1
+
+Invariant: dho-nz-pat-1
+Expression: "Patient.name.where( (use.empty()) or (use='nickname') or (use = 'maiden') or (use = 'temp') )"
+Severity: #error
+Description: "only allows certain name name use values"
 
 Profile: DHOPatientUpdate
 Parent: NzPatient
@@ -156,6 +189,8 @@ Description: "This profile derives from the [Patient](https://hl7.org/fhir/R4B/p
   * system 1..1 MS
   * value 1..1 MS
   * use 1..1 MS
+    * ^short = "home | work | mobile"
+    * ^definition = "The purpose of this contact point - constrained to home | work | mobile"
   * rank 0..1
   * id 0..0
 * birthDate 0..0

--- a/input/fsh/profiles/DHOPatient.fsh
+++ b/input/fsh/profiles/DHOPatient.fsh
@@ -33,7 +33,7 @@ RuleSet: CommonPatientConstraints
 * communication 0..0
 * managingOrganization 0..0
 * link 0..0
-* contained 0..1
+* contained 0..*
 * implicitRules 0..0
 * language 0..0
 // If you look at the definition of a FHIR patient (https://www.hl7.org/fhir/patient.html), deceased[x] is a a choice of data types
@@ -132,28 +132,27 @@ Description: "This profile derives from the [Patient](https://hl7.org/fhir/R4B/p
   * organization 0..0
   * period 0..1 MS
   * id 0..0
+* generalPractitioner 0..*
 
 // ---------------------------------------------------------
 // Reference constraints
 // ---------------------------------------------------------
 // * generalPractitioner only Reference(NzOrganization or NzPractitioner or NzPractitionerRole)
-// GP
-
 //Limit the possible resources for generalPractitioner only to a PractitionerRole
 //Note that this might still be a contained resource - that's still supported by this profile
-* generalPractitioner only Reference(PractitionerRole)
 
-* generalPractitioner 0..1
+* generalPractitioner only Reference(PractitionerRole or NzPractitioner or Organization)
+
 * generalPractitioner ^short = "Reference for the Patient's enrolled general Practitioner"
-* generalPractitioner ^definition = "The reference for the General Practice that the patient is enrolled with"
+* generalPractitioner ^definition = "The reference for the General Practice that the patient is enrolled with. May be a Practitioner, Nurse Practitioner or a Facility"
 
 // slice for contained practitionerRole
 * contained ^slicing.discriminator.type = #type
 * contained ^slicing.discriminator.path = "$this"
 * contained ^slicing.rules = #closed
 * contained ^slicing.description = "Slicing to specify a PractitionerRole resource may be returned as a contained resource for the Patient's General Practitioner information"
-* contained contains GP 0..1
-* contained[GP] only http://hl7.org/fhir/StructureDefinition/PractitionerRole
+* contained contains GP 0..*
+* contained[GP] only PractitionerRole
 * contained[GP] ^short = "Contained resource for the Patient's enrolled general Practitioner"
 * contained[GP] ^definition = "Contained resource for the General Practice that the patient is enrolled with"
 * obeys dho-nz-pat-1

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -342,7 +342,9 @@ groups:
   DHOExamples:
     name: Dunedin Hospital Outpatient examples
     resources:
-      - DHOPatientExample
+      - DHOPatientExampleGP
+      - DHOPatientExampleNP
+      - DHOPatientExampleMultiplePractitioners
       - DHOPatientUpdateExample
       - DHOAppointmentClinicExample
       - DHOAppointmentUnstructuredExample


### PR DESCRIPTION
This pull request makes several improvements and refinements to the Dunedin Hospital Outpatient FHIR profiles and examples. The most significant changes include enhanced support for general practitioner information (including contained resources), improved constraints and extensions for patient profiles, and updates to aliases and capability statements for better clarity and interoperability.

Enhancements to general practitioner representation:

* The `DHOPatient` profile now restricts `generalPractitioner` references to only `PractitionerRole`, supports a contained `PractitionerRole` resource for GP information, and adds slicing for contained resources. Example instances have been updated to use a contained `PractitionerRole` instead of inline practitioner details. [[1]](diffhunk://#diff-98030f5dce95678dc65f518f4f97ffdc495da5869b0850cbca54ca4ebd471be7L128-R166) [[2]](diffhunk://#diff-18508e15865a99216f587bf5ad7a8a560e4017a363a58147a6f892b632d90af3R1-R27) [[3]](diffhunk://#diff-18508e15865a99216f587bf5ad7a8a560e4017a363a58147a6f892b632d90af3R52-R53) [[4]](diffhunk://#diff-18508e15865a99216f587bf5ad7a8a560e4017a363a58147a6f892b632d90af3L92-R122)

Patient profile constraints and extensions:

* Added new constraints and extensions to the `DHOPatient` profile, including required ethnicity coding, improved citizenship extension with source coding, and enhancements to the `name` element (allowing specific uses and adding slicing for preferred names). Also clarified telecom usage and added narrative text for the profile. [[1]](diffhunk://#diff-98030f5dce95678dc65f518f4f97ffdc495da5869b0850cbca54ca4ebd471be7R5-R6) [[2]](diffhunk://#diff-98030f5dce95678dc65f518f4f97ffdc495da5869b0850cbca54ca4ebd471be7L21-R28) [[3]](diffhunk://#diff-98030f5dce95678dc65f518f4f97ffdc495da5869b0850cbca54ca4ebd471be7L59-R73) [[4]](diffhunk://#diff-98030f5dce95678dc65f518f4f97ffdc495da5869b0850cbca54ca4ebd471be7R192-R193)

Resource cardinality and slicing:

* Relaxed cardinality for `contained` resources in the patient profile, allowing up to one contained resource (for GP info), and defined slicing rules for contained `PractitionerRole`. [[1]](diffhunk://#diff-98030f5dce95678dc65f518f4f97ffdc495da5869b0850cbca54ca4ebd471be7L31-R38) [[2]](diffhunk://#diff-98030f5dce95678dc65f518f4f97ffdc495da5869b0850cbca54ca4ebd471be7L128-R166)

Alias and terminology updates:

* Refactored and expanded aliases for StructureDefinitions, CodeSystems, and ValueSets in `aliases.fsh` to improve clarity and ensure correct referencing throughout the project.

Capability statement improvements:

* Replaced generic CRUD interactions with explicit interaction definitions in the capability statement, enabling history and conditional updates for `Encounter` resources.