### PR TITLE
IMS-3606: Remove system value restriction for productOrService

### DIFF
--- a/input/fsh/extensions/NzTelehealthExtensions.fsh
+++ b/input/fsh/extensions/NzTelehealthExtensions.fsh
@@ -42,7 +42,6 @@ Title: "Shared Care Product Or Service"
 Description: "Validation and correction of purchase unit codes for shared care services"
 Context: ClaimResponse.item
 * value[x] only CodeableConcept
-* value[x].coding.system = "https://standards.digital.health.nz/ns/purchase-unit"
 
 // Extension: SharedCareItemTax
 // Id: shared-care-item-tax

--- a/input/fsh/extensions/NzTelehealthExtensions.fsh
+++ b/input/fsh/extensions/NzTelehealthExtensions.fsh
@@ -39,7 +39,7 @@ Context: Claim.item
 Extension: SharedCareProductOrService
 Id: shared-care-product-or-service
 Title: "Shared Care Product Or Service"
-Description: "Validation and correction of purchase unit codes for shared care services"
+Description: "Validation and correction of product or service code for shared care services"
 Context: ClaimResponse.item
 * value[x] only CodeableConcept
 

--- a/input/fsh/profiles/SharedCareClaimResponse.fsh
+++ b/input/fsh/profiles/SharedCareClaimResponse.fsh
@@ -7,7 +7,7 @@ Description: """A FHIR resource profile describing the outcome of NZ generic pay
 Note: In 4B item.adjudication, item.detail.adjudication, payment.amount, insurer are compulsory fields, but not utilized in the telehealth implementation.
       item.adjudication.quantity R5 is item.adjudication.value in R4B.
 """
-* ^version = "1.0.6"
+* ^version = "1.0.7"
 * ^purpose = "A FHIR resource profile describing the outcome of NZ generic payment claims"
 * ^status = #active
 * ^jurisdiction = urn:iso:std:iso:3166#NZ

--- a/input/fsh/profiles/nzpharmacyclaimresponse.fsh
+++ b/input/fsh/profiles/nzpharmacyclaimresponse.fsh
@@ -28,7 +28,7 @@ Description: "FHIR profile for New Zealand pharmacy claim responses"
 * item.itemSequence ^short = "To match Claim.item.sequence"
 
 * item.extension contains shared-care-product-or-service named productOrService 1..1
-* item.extension[productOrService] ^short = "Purchase unit code"
+* item.extension[productOrService] ^short = "Product or Service code"
 
 * item.detail 1..*
 * item.detail ^short = "Adjudication for claim detail items"


### PR DESCRIPTION
Remove system value restriction for SharedCare ClaimResponse.item productOrService extension as we expect purchase-unit code and product-code to be populated here (or more).