### PR TITLE
IMS-3717

### DIFF
--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -89,6 +89,7 @@ Alias: $ns-ethnic-group-level-4-code = https://standards.digital.health.nz/ns/et
 Alias: $ns-hpi-person-id = https://standards.digital.health.nz/ns/hpi-person-id
 Alias: $ns-information-source-code = https://standards.digital.health.nz/ns/information-source-code
 Alias: $ns-nz-citizenship-status-code = https://standards.digital.health.nz/ns/nz-citizenship-status-code
+Alias: $cs-telecom-validation-status = https://fhir-ig.digital.health.nz/shared-care/ValueSet/DHOTelecomValidationCS
 
 // ValueSets
 Alias: $vs-administrative-gender = http://hl7.org/fhir/ValueSet/administrative-gender

--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -89,7 +89,7 @@ Alias: $ns-ethnic-group-level-4-code = https://standards.digital.health.nz/ns/et
 Alias: $ns-hpi-person-id = https://standards.digital.health.nz/ns/hpi-person-id
 Alias: $ns-information-source-code = https://standards.digital.health.nz/ns/information-source-code
 Alias: $ns-nz-citizenship-status-code = https://standards.digital.health.nz/ns/nz-citizenship-status-code
-Alias: $cs-telecom-validation-status = https://fhir-ig.digital.health.nz/shared-care/ValueSet/DHOTelecomValidationCS
+Alias: $cs-telecom-validation-status = https://fhir-ig.digital.health.nz/shared-care/CodeSystem/DHOTelecomValidationCS
 
 // ValueSets
 Alias: $vs-administrative-gender = http://hl7.org/fhir/ValueSet/administrative-gender

--- a/input/fsh/examples/cinc/DHOPatientExample.fsh
+++ b/input/fsh/examples/cinc/DHOPatientExample.fsh
@@ -102,11 +102,17 @@ Usage: #example
 * telecom[=].use = #mobile
 * telecom[=].rank = 1
 * telecom[=].extension[notification-enabled].valueBoolean = true
+* telecom[=].extension[validation-status].valueCodeableConcept.coding.version = "0.4.5"
+* telecom[=].extension[validation-status].valueCodeableConcept.coding = $cs-telecom-validation-status#valid "Validated"
+* telecom[=].extension[validation-status].valueCodeableConcept.text = "Validated"
 * telecom[+].system = #email
 * telecom[=].value = "example@mail.com"
 * telecom[=].use = #home
 * telecom[=].rank = 2
 * telecom[=].extension[notification-enabled].valueBoolean = true
+* telecom[=].extension[validation-status].valueCodeableConcept.coding.version = "0.4.5"
+* telecom[=].extension[validation-status].valueCodeableConcept.coding = $cs-telecom-validation-status#valid "Validated"
+* telecom[=].extension[validation-status].valueCodeableConcept.text = "Validated"
 * gender = #female
 * birthDate = "1968-01-27"
 * address[+].type = #postal
@@ -197,6 +203,10 @@ Usage: #example
 * telecom[=].use = #mobile
 * telecom[=].rank = 1
 * telecom[=].extension[notification-enabled].valueBoolean = true
+* telecom[=].extension[validation-status].valueCodeableConcept.coding.version = "0.4.5"
+* telecom[=].extension[validation-status].valueCodeableConcept.coding = $cs-telecom-validation-status#ntvalid "Not Validated"
+* telecom[=].extension[validation-status].valueCodeableConcept.text = "Not Validated"
+
 * telecom[+].system = #email
 * telecom[=].value = "example@mail.com"
 * telecom[=].use = #home
@@ -294,11 +304,18 @@ Usage: #example
 * telecom[=].use = #mobile
 * telecom[=].rank = 1
 * telecom[=].extension[notification-enabled].valueBoolean = true
+* telecom[=].extension[validation-status].valueCodeableConcept.coding.version = "0.4.5"
+* telecom[=].extension[validation-status].valueCodeableConcept.coding = $cs-telecom-validation-status#pend "Pending"
+* telecom[=].extension[validation-status].valueCodeableConcept.text = "Pending"
 * telecom[+].system = #email
 * telecom[=].value = "example@mail.com"
 * telecom[=].use = #home
 * telecom[=].rank = 2
 * telecom[=].extension[notification-enabled].valueBoolean = true
+* telecom[=].extension[validation-status].valueCodeableConcept.coding.version = "0.4.5"
+* telecom[=].extension[validation-status].valueCodeableConcept.coding = $cs-telecom-validation-status#valid "Validated"
+* telecom[=].extension[validation-status].valueCodeableConcept.text = "Validated"
+
 * gender = #female
 * birthDate = "1968-01-27"
 * address[+].type = #postal
@@ -365,8 +382,14 @@ Description: "An example Dunedin Hospital Outpatient Update demographics (phone 
 * telecom[=].use = #mobile
 * telecom[=].rank = 1
 * telecom[=].extension[notification-enabled].valueBoolean = true
+* telecom[=].extension[validation-status].valueCodeableConcept.coding.version = "0.4.5"
+* telecom[=].extension[validation-status].valueCodeableConcept.coding = $cs-telecom-validation-status#valid "Validated"
+* telecom[=].extension[validation-status].valueCodeableConcept.text = "Validated"
 * telecom[+].system = #email
 * telecom[=].value = "example@mail.com"
 * telecom[=].use = #home
 * telecom[=].rank = 2
 * telecom[=].extension[notification-enabled].valueBoolean = true
+* telecom[=].extension[validation-status].valueCodeableConcept.coding.version = "0.4.5"
+* telecom[=].extension[validation-status].valueCodeableConcept.coding = $cs-telecom-validation-status#valid "Validated"
+* telecom[=].extension[validation-status].valueCodeableConcept.text = "Validated"

--- a/input/fsh/examples/cinc/DHOPatientExample.fsh
+++ b/input/fsh/examples/cinc/DHOPatientExample.fsh
@@ -159,6 +159,103 @@ Usage: #example
 
 * generalPractitioner[+] = Reference(DHOPractitionerRole1)
 
+Instance: DHOPatientExampleGPDeceased
+InstanceOf: DHOPatient
+Description: "An example Dunedin Hospital Outpatient with a GP"
+Usage: #example
+
+* id = "DHO-outpatient-instance-gp-deceased"
+* meta.versionId = "1"
+* meta.lastUpdated = "2025-09-04T09:00:00.000Z"
+* meta.profile = "https://fhir-ig.digital.health.nz/shared-care/StructureDefinition/DHOPatient"
+* meta.source = "https://standards.digital.health.nz/ns/hpi-facility-id/F04066-D"
+* insert CorrelationIdTag(xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
+
+* extension[sex-at-birth].valueCodeableConcept.coding.version = "4.0.1"
+* extension[sex-at-birth].valueCodeableConcept.coding.system = "http://hl7.org/fhir/administrative-gender"
+* extension[sex-at-birth].valueCodeableConcept = #female
+
+* extension[ethnicity].valueCodeableConcept.coding.version = "2.0"
+* extension[ethnicity].valueCodeableConcept.coding = $ns-ethnic-group-level-4-code#21111 "Māori"
+* extension[ethnicity].valueCodeableConcept.text = "Māori"
+* extension[nz-citizenship].extension[+].url = "source"
+* extension[nz-citizenship].extension[=].valueCodeableConcept.coding.version = "1.0.0"
+* extension[nz-citizenship].extension[=].valueCodeableConcept.coding = $ns-information-source-code#BREG "Birth Register"
+* extension[nz-citizenship].extension[=].valueCodeableConcept.text = "Birth Register"
+* extension[nz-citizenship].extension[+].url = "status"
+* extension[nz-citizenship].extension[=].valueCodeableConcept.coding.version = "1.1.0"
+* extension[nz-citizenship].extension[=].valueCodeableConcept.coding = $ns-nz-citizenship-status-code#no "No"
+* extension[nz-citizenship].extension[=].valueCodeableConcept.text = "No"
+* extension[interpreter-required].valueBoolean = false
+
+* contained[GP] = DHOPractitionerRole1
+
+* identifier insert NHIIdentifier(ZXP7823)
+* active = true
+* name.use = #usual
+* name.text = "Miss Carey Mary Carrington"
+* name.family = "Carrington"
+* name.given[+] = "Carey"
+* name.given[+] = "Mary"
+* name.prefix = "Miss"
+* telecom[+].system = #phone
+* telecom[=].value = "+64 21 123 4567"
+* telecom[=].use = #mobile
+* telecom[=].rank = 1
+* telecom[=].extension[notification-enabled].valueBoolean = true
+* telecom[+].system = #email
+* telecom[=].value = "example@mail.com"
+* telecom[=].use = #home
+* telecom[=].rank = 2
+* telecom[=].extension[notification-enabled].valueBoolean = true
+* gender = #female
+* birthDate = "1968-01-27"
+* deceasedDateTime = "2026-04-21"
+* address[+].type = #postal
+* address[=].extension[+].url = "http://hl7.org.nz/fhir/StructureDefinition/domicile-code"
+* address[=].extension[=].valueCodeableConcept.text = "Dunedin Central"
+* address[=].extension[+].url = "http://hl7.org.nz/fhir/StructureDefinition/suburb"
+* address[=].extension[=].valueString = "Dunedin"
+* address[=].line = "360 Cumberland Street"
+* address[=].postalCode = "9016"
+* address[=].country = "NEW ZEALAND"
+* address[=].use = #work
+* address[+].type = #physical
+* address[=].extension[+].url = "http://hl7.org.nz/fhir/StructureDefinition/domicile-code"
+* address[=].extension[=].valueCodeableConcept = $ns-domicile-code#2898 "Maori Hill"
+* address[=].extension[=].valueCodeableConcept.text = "Maori Hill"
+* address[=].extension[+].url = "http://hl7.org.nz/fhir/StructureDefinition/suburb"
+* address[=].extension[=].valueString = "Maori Hill"
+* address[=].line = "481 Highgate"
+* address[=].postalCode = "9010"
+* address[=].country = "NEW ZEALAND"
+* address[=].use = #home
+* maritalStatus.coding[+].code = #S
+* maritalStatus.coding[=].system = "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus"
+* maritalStatus.coding[=].display = "Never Married"
+* contact[+].name.text = "John NextOfKin"
+* contact[=].name.family = "NextOfKin"
+* contact[=].name.given = "John Test"
+* contact[=].telecom[+].system = #phone
+* contact[=].telecom[=].use = #mobile
+* contact[=].telecom[=].value = "+64 27 123 4567"
+* contact[=].extension[+].url = Canonical(dho-patient-contact-role-extension-id)
+* contact[=].extension[=].valueCodeableConcept = $cs-patient-contact-role#nok "Next of Kin"
+* contact[=].extension[=].valueCodeableConcept.text = "Next of Kin"
+
+* contact[+].name.text = "Mary PowerOfAttorney"
+* contact[=].name.family = "PowerOfAttorney"
+* contact[=].name.given = "Mary"
+* contact[=].telecom[+].system = #phone
+* contact[=].telecom[=].use = #mobile
+* contact[=].telecom[=].value = "+64 22 123 4567"
+* contact[=].extension[+].url = Canonical(dho-patient-contact-role-extension-id)
+* contact[=].extension[=].valueCodeableConcept = $cs-patient-contact-role#powatt "Power of Attorney"
+* contact[=].extension[=].valueCodeableConcept.text = "Power of Attorney"
+
+* generalPractitioner[+] = Reference(DHOPractitionerRole1)
+
+
 Instance: DHOPatientExampleNP
 InstanceOf: DHOPatient
 Description: "An example Dunedin Hospital Outpatient with a Nurse Practitioner"

--- a/input/fsh/examples/cinc/DHOPatientExample.fsh
+++ b/input/fsh/examples/cinc/DHOPatientExample.fsh
@@ -204,7 +204,7 @@ Usage: #example
 * telecom[=].rank = 1
 * telecom[=].extension[notification-enabled].valueBoolean = true
 * telecom[=].extension[validation-status].valueCodeableConcept.coding.version = "0.4.5"
-* telecom[=].extension[validation-status].valueCodeableConcept.coding = $cs-telecom-validation-status#ntvalid "Not Validated"
+* telecom[=].extension[validation-status].valueCodeableConcept.coding = $cs-telecom-validation-status#ntval "Not Validated"
 * telecom[=].extension[validation-status].valueCodeableConcept.text = "Not Validated"
 
 * telecom[+].system = #email

--- a/input/fsh/extensions/DHOTelecomValidation.fsh
+++ b/input/fsh/extensions/DHOTelecomValidation.fsh
@@ -25,4 +25,6 @@ Id: dho-telecom-validation
 Title: "DHO Telecom Validation Status"
 Description: "The Validation status of the telecom. Used when the system type is 'email', 'sms', or 'phone' with use 'mobile'."
 Context: ContactPoint
+* value[x] only CodeableConcept
+* valueCodeableConcept 1..1
 * valueCodeableConcept from DHOTelecomValidationVS (required)

--- a/input/fsh/extensions/DHOTelecomValidation.fsh
+++ b/input/fsh/extensions/DHOTelecomValidation.fsh
@@ -1,0 +1,24 @@
+CodeSystem: DHOTelecomValidationCS
+Title: "DHOPatient Telecom Validation Status"
+Description: "Indicates the validation status of a telecom."
+* ^caseSensitive = true
+* ^experimental = false
+* #failed "Failed"
+* #inpro "In Progress"
+* #ntval "Not Validated"
+* #pend "Pending"
+* #valid "Validated"
+
+ValueSet: DHOTelecomValidationVS
+Id: DHOTelecomValidationVS
+Title: "Allowed Telecom Validation Statuses"
+Description: "Allowed validation statuses for DHOPatient"
+* include codes from system DHOTelecomValidationCS
+
+
+Extension: DHOTelecomValidation
+Id: dho-telecom-validation
+Title: "DHO Telecom Validation Status"
+Description: "The Validation status of the telecom. Used when the system type is 'email', 'sms', or 'phone' with use 'mobile'."
+Context: ContactPoint
+* valueCodeableConcept from DHOTelecomValidationVS (required)

--- a/input/fsh/extensions/DHOTelecomValidation.fsh
+++ b/input/fsh/extensions/DHOTelecomValidation.fsh
@@ -1,6 +1,10 @@
 CodeSystem: DHOTelecomValidationCS
+Id: DHOTelecomValidationCS
 Title: "DHOPatient Telecom Validation Status"
 Description: "Indicates the validation status of a telecom."
+* ^url = "https://fhir-ig.digital.health.nz/shared-care/CodeSystem/DHOTelecomValidationCS"
+* ^status = #active
+* ^publisher = "Te Whatu Ora"
 * ^caseSensitive = true
 * ^experimental = false
 * #failed "Failed"

--- a/input/fsh/profiles/DHOPatient.fsh
+++ b/input/fsh/profiles/DHOPatient.fsh
@@ -75,6 +75,9 @@ Description: "This profile derives from the [Patient](https://hl7.org/fhir/R4B/p
   * extension contains DHOTelecomNotification named notification-enabled 0..1 MS
   * extension[notification-enabled] ^short = "True if notifications can be sent to this email or SMS address"
   * extension[cp-purpose] 0..0
+  * obeys dho-telecom-validation-system
+  * extension contains DHOTelecomValidation named validation-status 0..1 MS
+  * extension[validation-status] ^short = "Validation status of this telecom"
   * period 0..0
   * system 1..1 MS
   * value 1..1 MS
@@ -181,6 +184,8 @@ Description: "This profile derives from the [Patient](https://hl7.org/fhir/R4B/p
   * obeys dho-telecom-notification-valid-system
   * extension contains DHOTelecomNotification named notification-enabled 0..1 MS
   * extension[notification-enabled] ^short = "True if notifications can be sent to this email or SMS address"
+  * extension contains DHOTelecomValidation named validation-status 0..1 MS
+  * extension[validation-status] ^short = "Validation status of this telecoms"
   * extension[cp-purpose] 0..0
   * period 0..0
   * system 1..1 MS
@@ -203,3 +208,8 @@ Invariant: dho-telecom-notification-valid-system
 Description: "The notification-enabled extension should only be present when the telecom system is 'email', 'sms', or 'phone' with use 'mobile'."
 Severity: #warning
 Expression: "extension.where(url = 'https://fhir-ig.digital.health.nz/shared-care/StructureDefinition/dho-telecom-notification').exists() implies (system = 'email' or system = 'sms' or (system = 'phone' and use = 'mobile'))"
+
+Invariant: dho-telecom-validation-system
+Description: "The validation-status extension should only be present when the telecom system is 'email', 'sms', or 'phone' with use 'mobile'."
+Severity: #warning
+Expression: "extension.where(url = 'https://fhir-ig.digital.health.nz/shared-care/StructureDefinition/dho-telecom-validation').exists() implies (system = 'email' or system = 'sms' or (system = 'phone' and use = 'mobile'))"

--- a/input/fsh/profiles/DHOPatient.fsh
+++ b/input/fsh/profiles/DHOPatient.fsh
@@ -136,6 +136,7 @@ Description: "This profile derives from the [Patient](https://hl7.org/fhir/R4B/p
   * period 0..1 MS
   * id 0..0
 * generalPractitioner 0..*
+* extension[ethnicity] 0..*
 
 // ---------------------------------------------------------
 // Reference constraints

--- a/input/fsh/profiles/DHOPatient.fsh
+++ b/input/fsh/profiles/DHOPatient.fsh
@@ -184,8 +184,9 @@ Description: "This profile derives from the [Patient](https://hl7.org/fhir/R4B/p
   * obeys dho-telecom-notification-valid-system
   * extension contains DHOTelecomNotification named notification-enabled 0..1 MS
   * extension[notification-enabled] ^short = "True if notifications can be sent to this email or SMS address"
+  * obeys dho-telecom-validation-system
   * extension contains DHOTelecomValidation named validation-status 0..1 MS
-  * extension[validation-status] ^short = "Validation status of this telecoms"
+  * extension[validation-status] ^short = "Validation status of this telecom"
   * extension[cp-purpose] 0..0
   * period 0..0
   * system 1..1 MS


### PR DESCRIPTION
- Add `DHOTelecomValidation` extension to `DHOPatient` to support telecom validation statuses.
- Update `DHOPatientExample` with validation status examples.
- Introduce `DHOTelecomValidationCS` CodeSystem and `DHOTelecomValidationVS` ValueSet.
- Update aliases to include telecom validation system reference.

This pull request introduces a new extension to capture the validation status of patient contact details (telecom) in the DHOPatient profile. It defines a new code system and value set for telecom validation statuses, adds the extension and related constraints to the patient profile, and updates example data to demonstrate its use.

**Extension and Terminology Additions:**

* Created a new `DHOTelecomValidation` extension for `ContactPoint`, along with a supporting code system (`DHOTelecomValidationCS`) and value set (`DHOTelecomValidationVS`) to represent telecom validation statuses such as "Validated", "Pending", "Not Validated", etc. (`input/fsh/extensions/DHOTelecomValidation.fsh`)
* Added an alias for the new code system URL to `aliases.fsh`. (`input/fsh/aliases.fsh`)

**Profile Enhancements:**

* Updated the `DHOPatient` profile to include the new `DHOTelecomValidation` extension on telecom elements, with a short description and a new invariant (`dho-telecom-validation-system`) ensuring the extension is only present for relevant system types. (`input/fsh/profiles/DHOPatient.fsh`) [[1]](diffhunk://#diff-98030f5dce95678dc65f518f4f97ffdc495da5869b0850cbca54ca4ebd471be7R78-R80) [[2]](diffhunk://#diff-98030f5dce95678dc65f518f4f97ffdc495da5869b0850cbca54ca4ebd471be7R187-R188) [[3]](diffhunk://#diff-98030f5dce95678dc65f518f4f97ffdc495da5869b0850cbca54ca4ebd471be7R211-R215)

**Example Updates:**

* Enhanced the `DHOPatientExample` to show various uses of the new validation status extension, with different statuses and value representations for telecom entries. (`input/fsh/examples/cinc/DHOPatientExample.fsh`) [[1]](diffhunk://#diff-18508e15865a99216f587bf5ad7a8a560e4017a363a58147a6f892b632d90af3R105-R115) [[2]](diffhunk://#diff-18508e15865a99216f587bf5ad7a8a560e4017a363a58147a6f892b632d90af3R206-R209) [[3]](diffhunk://#diff-18508e15865a99216f587bf5ad7a8a560e4017a363a58147a6f892b632d90af3R307-R318) [[4]](diffhunk://#diff-18508e15865a99216f587bf5ad7a8a560e4017a363a58147a6f892b632d90af3R385-R395)