### PR TITLE
feature/IMS-3764

### DIFF
--- a/input/fsh/examples/cinc/DHOPatientExample.fsh
+++ b/input/fsh/examples/cinc/DHOPatientExample.fsh
@@ -133,7 +133,8 @@ Usage: #example
 * maritalStatus.coding[=].display = "Never Married"
 * contact[+].name.text = "John NextOfKin"
 * contact[=].name.family = "NextOfKin"
-* contact[=].name.given = "John Test"
+* contact[=].name.given[+] = "John"
+* contact[=].name.given[+] = "Test"
 * contact[=].telecom[+].system = #phone
 * contact[=].telecom[=].use = #mobile
 * contact[=].telecom[=].value = "+64 27 123 4567"
@@ -228,7 +229,8 @@ Usage: #example
 * maritalStatus.coding[=].display = "Never Married"
 * contact[+].name.text = "John NextOfKin"
 * contact[=].name.family = "NextOfKin"
-* contact[=].name.given = "John Test"
+* contact[=].name.given[+] = "John"
+* contact[=].name.given[+] = "Test"
 * contact[=].telecom[+].system = #phone
 * contact[=].telecom[=].use = #mobile
 * contact[=].telecom[=].value = "+64 27 123 4567"
@@ -325,7 +327,8 @@ Usage: #example
 * maritalStatus.coding[=].display = "Never Married"
 * contact[+].name.text = "John NextOfKin"
 * contact[=].name.family = "NextOfKin"
-* contact[=].name.given = "John Test"
+* contact[=].name.given[+] = "John"
+* contact[=].name.given[+] = "Test"
 * contact[=].telecom[+].system = #phone
 * contact[=].telecom[=].use = #mobile
 * contact[=].telecom[=].value = "+64 27 123 4567"

--- a/input/fsh/profiles/DHOPatient.fsh
+++ b/input/fsh/profiles/DHOPatient.fsh
@@ -63,7 +63,7 @@ Description: "This profile derives from the [Patient](https://hl7.org/fhir/R4B/p
   * use 1..1 MS
     * ^short = "usual | temp | nickname | maiden"
   * family 1..1 MS
-  * given 0..5 MS
+  * given 0..* MS
     * ^short = "Given name and other given name(s)"
     * ^definition = "Given name and other given name(s) for the patient"
   * prefix from $vs-name-prefix
@@ -115,7 +115,7 @@ Description: "This profile derives from the [Patient](https://hl7.org/fhir/R4B/p
     * use 0..0
     * text 1..1 MS
     * family 1..1 MS
-    * given MS
+    * given 1..* MS
     * prefix 0..1 MS
     * suffix 0..0
     * extension 0..0

--- a/input/fsh/profiles/DHOPatient.fsh
+++ b/input/fsh/profiles/DHOPatient.fsh
@@ -63,7 +63,7 @@ Description: "This profile derives from the [Patient](https://hl7.org/fhir/R4B/p
   * use 1..1 MS
     * ^short = "usual | temp | nickname | maiden"
   * family 1..1 MS
-  * given 0..5 MS
+  * given 0..* MS
     * ^short = "Given name and other given name(s)"
     * ^definition = "Given name and other given name(s) for the patient"
   * prefix from $vs-name-prefix
@@ -115,7 +115,7 @@ Description: "This profile derives from the [Patient](https://hl7.org/fhir/R4B/p
     * use 0..0
     * text 1..1 MS
     * family 1..1 MS
-    * given MS
+    * given 0..* MS
     * prefix 0..1 MS
     * suffix 0..0
     * extension 0..0


### PR DESCRIPTION
- Update `DHOPatient` profile to allow multiple given names for patient and contact names.
- Adjust `DHOPatientExample` to reflect updated `given` field constraints.

This pull request updates the `DHOPatient` profile and its example to improve how given names are represented for patient contacts. The main changes ensure that the `given` name field can accommodate multiple entries and that this is reflected in both the profile definition and the example data.

**Profile definition updates:**

* Changed the cardinality of the `given` field in `Patient.name` from `0..5` to `0..*`, allowing for an unlimited number of given names.
* Updated the `given` field in `Patient.contact.name` to require at least one given name and allow multiple (`1..*`).

**Example data updates:**

* Modified all instances in `DHOPatientExample.fsh` where a contact's given name was previously a single string (`"John Test"`) to now use two separate entries: `"John"` and `"Test"`. This matches the updated cardinality and structure. [[1]](diffhunk://#diff-18508e15865a99216f587bf5ad7a8a560e4017a363a58147a6f892b632d90af3L136-R137) [[2]](diffhunk://#diff-18508e15865a99216f587bf5ad7a8a560e4017a363a58147a6f892b632d90af3L231-R233) [[3]](diffhunk://#diff-18508e15865a99216f587bf5ad7a8a560e4017a363a58147a6f892b632d90af3L328-R331)